### PR TITLE
Convert hook context models to dataclasses

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "python.analysis.autoImportCompletions": true
+    "python.analysis.autoImportCompletions": false
 }

--- a/nonebot_plugin_value/hook/context.py
+++ b/nonebot_plugin_value/hook/context.py
@@ -1,20 +1,21 @@
 # 事件钩子上下文
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field
 
 from .exception import CancelAction, DataUpdate
 
 
-class TransactionContext(BaseModel):
+@dataclass
+class TransactionContext:
     """Transaction context
 
     Args:
-        BaseModel (BaseModel): extends pydantic BaseModel
+        BaseModel : extends pydantic BaseModel
     """
 
-    user_id: str = Field(default_factory=str)  # 用户的唯一标识ID
-    currency: str = Field(default_factory=str)  # 货币种类
-    amount: float = Field(default_factory=float)  # 金额（+或-）
-    action_type: str = Field(default_factory=str)  # 操作类型（参考Method类）
+    user_id: str = field(default_factory=str)  # 用户的唯一标识ID
+    currency: str = field(default_factory=str)  # 货币种类
+    amount: float = field(default_factory=float)  # 金额（+或-）
+    action_type: str = field(default_factory=str)  # 操作类型（参考Method类）
 
     def cancel(self, reason: str = ""):
         raise CancelAction(reason)
@@ -22,16 +23,16 @@ class TransactionContext(BaseModel):
     def commit_update(self):
         raise DataUpdate(amount=self.amount)
 
-
-class TransactionComplete(BaseModel):
+@dataclass
+class TransactionComplete:
     """Transaction complete
 
     Args:
-        BaseModel (BaseModel): extends pydantic BaseModel
+        BaseModel : extends pydantic BaseModel
     """
 
-    message: str = Field(default="")
-    source_balance: float = Field(default_factory=float)
-    new_balance: float = Field(default_factory=float)
-    timestamp: float = Field(default_factory=float)
-    user_id: str = Field(default_factory=str)
+    message: str = field(default="")
+    source_balance: float = field(default_factory=float)
+    new_balance: float = field(default_factory=float)
+    timestamp: float = field(default_factory=float)
+    user_id: str = field(default_factory=str)

--- a/nonebot_plugin_value/hook/context.py
+++ b/nonebot_plugin_value/hook/context.py
@@ -23,6 +23,7 @@ class TransactionContext:
     def commit_update(self):
         raise DataUpdate(amount=self.amount)
 
+
 @dataclass
 class TransactionComplete:
     """Transaction complete

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ default = [
 
 [[package]]
 name = "nonebot-plugin-value"
-version = "0.1.4.post1"
+version = "0.1.6.post1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Sourcery 总结

将 hook 上下文模型从 Pydantic BaseModel 转换为 Python dataclasses

改进点:
- 将 TransactionContext 和 TransactionComplete 类替换为 @dataclass 实现
- 将字段定义从 pydantic Field 切换到 dataclasses.field 并更新导入

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert hook context models from Pydantic BaseModel to Python dataclasses

Enhancements:
- Replace TransactionContext and TransactionComplete classes with @dataclass implementations
- Switch field definitions from pydantic Field to dataclasses.field and update imports

</details>